### PR TITLE
Set BloodType RawValue as String

### DIFF
--- a/Sources/FakeFortuneTelling/BloodType.swift
+++ b/Sources/FakeFortuneTelling/BloodType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum BloodType: Decodable {
+public enum BloodType: String, Decodable {
     
     case o
     case a


### PR DESCRIPTION
`RawValue` を定義しておかないと `"blood_type": "ab"` のJSON連想配列からデコードできないので、それを追加します