### PR TITLE
Feature/decoding assertion fix

### DIFF
--- a/Sources/FakeFortuneTelling/Name.swift
+++ b/Sources/FakeFortuneTelling/Name.swift
@@ -29,7 +29,7 @@ extension Name: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let text = try container.decode(String.self)
-        self.text = text
+        try self.init(text: text)
     }
     
 }

--- a/Sources/FakeFortuneTelling/YearMonthDay.swift
+++ b/Sources/FakeFortuneTelling/YearMonthDay.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct YearMonthDay: Decodable {
+public struct YearMonthDay {
     
     public enum Error: Swift.Error {
         case invalidDate
@@ -27,6 +27,25 @@ public struct YearMonthDay: Decodable {
         self.year = year
         self.month = month
         self.day = day
+        
+    }
+    
+}
+
+extension YearMonthDay: Decodable {
+    
+    private enum CodingKeys: CodingKey {
+        case year, month, day
+    }
+    
+    public init(from decoder: Decoder) throws {
+        
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let year = try container.decode(Int.self, forKey: .year)
+        let month = try container.decode(Int.self, forKey: .month)
+        let day = try container.decode(Int.self, forKey: .day)
+        
+        try self.init(year: year, month: month, day: day)
         
     }
     

--- a/Tests/FakeFortuneTellingTests/YearMonthDayTests.swift
+++ b/Tests/FakeFortuneTellingTests/YearMonthDayTests.swift
@@ -1,0 +1,67 @@
+//
+//  YearMonthDayTests.swift
+//  
+//
+//  Created by 史 翔新 on 2023/04/10.
+//
+
+import Foundation
+import XCTest
+@testable import FakeFortuneTelling
+
+final class YearMonthDayTests: XCTestCase {
+    
+    func test_normalInitialize() throws {
+        
+        let yearMonthDay = try YearMonthDay(year: 2023, month: 4, day: 10)
+        
+        XCTAssertEqual(yearMonthDay.year, 2023)
+        XCTAssertEqual(yearMonthDay.month, 4)
+        XCTAssertEqual(yearMonthDay.day, 10)
+        
+    }
+    
+    func test_failingInitialize() throws {
+        
+        XCTAssertThrowsError(try YearMonthDay(year: 2023, month: 4, day: 31))
+        XCTAssertThrowsError(try YearMonthDay(year: 2023, month: 13, day: 10))
+        XCTAssertThrowsError(try YearMonthDay(year: 2023, month: 0, day: 10))
+        XCTAssertThrowsError(try YearMonthDay(year: 2023, month: 4, day: 0))
+        
+    }
+    
+    func test_normalDecoding() throws {
+        
+        let json = """
+        {
+            "year": 2023,
+            "month": 4,
+            "day": 10
+        }
+        """.data(using: .utf8)!
+        
+        let decoder = JSONDecoder()
+        let yearMonthDay = try decoder.decode(YearMonthDay.self, from: json)
+        
+        XCTAssertEqual(yearMonthDay.year, 2023)
+        XCTAssertEqual(yearMonthDay.month, 4)
+        XCTAssertEqual(yearMonthDay.day, 10)
+        
+    }
+    
+    func test_failingDecoding() throws {
+            
+            let json = """
+            {
+                "year": 2023,
+                "month": 4,
+                "day": 31
+            }
+            """.data(using: .utf8)!
+            
+            let decoder = JSONDecoder()
+            XCTAssertThrowsError(try decoder.decode(YearMonthDay.self, from: json))
+            
+    }
+    
+}


### PR DESCRIPTION
YearMonthDayのInitializerで日付が正規だどうかの確認がありますが、実際に使われているDecodingのロジックではそれがなかったので、Decoding時にもちゃんとInitializerを使うようにコード修正しました